### PR TITLE
Prevent KeyErrors on pages without canonical urls

### DIFF
--- a/pageinfo/pageinfo.py
+++ b/pageinfo/pageinfo.py
@@ -66,6 +66,8 @@ def get_meta(url):
                     data["facebook"][tag_type] = tag['content']
                     if tag_type == "og:description" and data["description"] is None:
                         data["description"] = tag["content"]
+            else:
+                data["facebook"] = {}
 
             #get twitter card data
             if soup.findAll('meta', attrs={'name':re.compile("^twitter")}):
@@ -77,7 +79,7 @@ def get_meta(url):
                             data["description"] = tag["content"]
             # make sure canonical exists, use og as backup
             if not data['canonical'] or len(data['canonical']) == 0:
-                if data.get('facebook') and data['facebook'].has_key('og:url'):
+                if data['facebook'].has_key('og:url'):
                     data['canonical'] = data['facebook']['og:url']
             if not data['canonical'] or len(data['canonical']) == 0:
                 data['canonical'] = url

--- a/pageinfo/pageinfo.py
+++ b/pageinfo/pageinfo.py
@@ -26,6 +26,7 @@ def get_meta(url):
     
     data = {}
     data["title"] = ""
+    data["canonical"] = None
     data["description"] = None
     data["favicon"] = None
     data["facebook"] = {}
@@ -43,8 +44,6 @@ def get_meta(url):
             canonical = soup.find("link", rel="canonical")
             if canonical:
                 data["canonical"] = canonical['href']
-            else:
-                data["canonical"] = None
             #get favicon
             parsed_uri = urlparse( url )
             if soup.find("link", rel="shortcut icon"):
@@ -66,8 +65,6 @@ def get_meta(url):
                     data["facebook"][tag_type] = tag['content']
                     if tag_type == "og:description" and data["description"] is None:
                         data["description"] = tag["content"]
-            else:
-                data["facebook"] = {}
 
             #get twitter card data
             if soup.findAll('meta', attrs={'name':re.compile("^twitter")}):

--- a/pageinfo/pageinfo.py
+++ b/pageinfo/pageinfo.py
@@ -43,6 +43,8 @@ def get_meta(url):
             canonical = soup.find("link", rel="canonical")
             if canonical:
                 data["canonical"] = canonical['href']
+            else:
+                data["canonical"] = None
             #get favicon
             parsed_uri = urlparse( url )
             if soup.find("link", rel="shortcut icon"):
@@ -75,7 +77,7 @@ def get_meta(url):
                             data["description"] = tag["content"]
             # make sure canonical exists, use og as backup
             if not data['canonical'] or len(data['canonical']) == 0:
-                if data['facebook'].has_key('og:url'):
+                if data.get('facebook') and data['facebook'].has_key('og:url'):
                     data['canonical'] = data['facebook']['og:url']
             if not data['canonical'] or len(data['canonical']) == 0:
                 data['canonical'] = url


### PR DESCRIPTION
I am getting a KeyError when a page doesn't have a canonical URL tag, on line 77 here:
![image](https://cloud.githubusercontent.com/assets/1697151/3417277/3e75fe46-fe37-11e3-8b03-fe9569a954cc.png)
I think this PR catches any such errors...handle it however you like.
Thanks!
